### PR TITLE
Fixed Popup Modal if Confidence Interval is null

### DIFF
--- a/src/PopupModal.jsx
+++ b/src/PopupModal.jsx
@@ -102,7 +102,12 @@ class PopupModal extends Component {
                 var valTable = classifications[classOpt].values
                 for (var value in valTable) {
                     if (value == fieldID) {
-                        valueBody.push(<Body> {classifications[classOpt].name} {valTable[value]} </Body> )
+                        var valueBack = valTable[value]
+                        if (isNaN(valueBack)){
+                            valueBody.push(<Body> {classifications[classOpt].name} null </Body> )
+                         } else{
+                            valueBody.push(<Body> {classifications[classOpt].name} {valTable[value]} </Body> )
+                         }
                     }
                 }
             }


### PR DESCRIPTION
After a recently added feature of adding the confidence interval to the fields, there was a bug where if the Confidence Interval was null the page would break. We fixed that by setting it to null.