### PR TITLE
Added more Intuitive Naming for sort functions

### DIFF
--- a/src/Classifications.jsx
+++ b/src/Classifications.jsx
@@ -4,20 +4,20 @@ import EnhancedTable from './EnhancedTable.jsx'
 // MAKE THIS ONLY DISPLAY NON-WORKBENCH CLASSIFICATIONS
 const sortMethods = (values) => {
     return {
-      AlphabeticalD: function (a, b) {
+      "A-z": function (a, b) {
         return values[a].name > values[b].name ? 1 : (
           values[a].name < values[b].name ? -1 : 0
         )
       },
-      AlphabeticalA: function (a, b) {
+      "Z-a": function (a, b) {
         return values[a].name > values[b].name ? -1 : (
           values[a].name < values[b].name ? 1 : 0
         )
       },
-      SizeD: function(a, b) {
+      "Size (Asc.)": function(a, b) {
         return Object.keys(values[a].values).length - Object.keys(values[b].values).length
       },
-      SizeA: function(a, b) {
+      "Size (Desc.)": function(a, b) {
         return Object.keys(values[b].values).length - Object.keys(values[a].values).length
       }
     }

--- a/src/EnhancedTable.jsx
+++ b/src/EnhancedTable.jsx
@@ -58,7 +58,7 @@ class EnhancedTable extends React.Component {
         values: {}
       },
       open: false,
-      sortMethod: "AlphabeticalD",
+      sortMethod: "A-z",
       methodsList: this.props.sortMethods(this.props.values)
     };
     console.log(Object.keys(this.state.methodsList))

--- a/src/Fields.jsx
+++ b/src/Fields.jsx
@@ -3,12 +3,12 @@ import EnhancedTable from './EnhancedTable.jsx'
 
 const sortMethods = (values) => {
   return {
-    AlphabeticalD: function (a, b) {
+    "A-z": function (a, b) {
       return values[a].name > values[b].name ? 1 : (
         values[a].name < values[b].name ? -1 : 0
       )
     },
-    AlphabeticalA: function (a, b) {
+    "Z-a": function (a, b) {
       return values[a].name > values[b].name ? -1 : (
         values[a].name < values[b].name ? 1 : 0
       )


### PR DESCRIPTION
Per a bug reported by a visiting tester, the team became aware that the naming conventions of the sorting methods were not intuitive and confused users. As a result, I added a small UI fix that made it easier for a user to sort classifications/fields. I also set the default sort for both as alphabetical A-z. 